### PR TITLE
Fix KeyError in create_geojson function by correctly handling cid

### DIFF
--- a/src/viz_utils.py
+++ b/src/viz_utils.py
@@ -18,6 +18,8 @@ from src.constants import (
 
 def create_geojson(polygons, classids, lookup, result_dir):
     features = []
+    if isinstance(classids[0], (list, tuple)):
+        classids = [cid[0] for cid in classids]
     for i, (poly, cid) in enumerate(zip(polygons, classids)):
         poly = np.array(poly)
         poly = poly[:, [1, 0]]


### PR DESCRIPTION
#### Description:
This pull request fixes the `KeyError` issue in the `create_geojson` function found in `viz_utils.py`. The error occurs because the `cid` value is always a list or tuple, which leads to an incorrect key lookup in the `lookup` dictionary.

#### Changes Made:
- Added a check to see if `classids` is a list or tuple and extract the first element of `cid` outside the loop. This ensures that `cid` is correctly used as a key in the `lookup` dictionary.

#### Issue Reference:
This pull request addresses issue #4, where the `KeyError` was reported.

#### Error Message:
```bash
Traceback (most recent call last):
  File "path/to/main.py", line 232, in <module>
    main(params)
  File "path/to/main.py", line 117, in main
    z_pp = post_process_main(
           ^^^^^^^^^^^^^^^^^^
  File "path/to/src/post_process.py", line 95, in post_process_main
    create_polygon_output(pinst_out, pcls_out, params["output_dir"], params)
  File "path/to/src/viz_utils.py", line 118, in create_polygon_output
    create_geojson(
  File "path/to/src/viz_utils.py", line 34, in create_geojson
    "name": lookup[cid],
            ~~~~~~^^^^^
KeyError: (6, (1248.144578313253, 9795.885542168675))

```