### PR TITLE
Fixed 80x and sped up geojson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,10 @@ pannuke_convnextv2_tiny_3/*
 sample/*
 testo.py
 test_out.csv
+cpu_pp_pannuke_debug.sh
+run_inference_container_pannuke_debug.sh
+run_mit_inference.sh
+sample_cls.bmp
+sample_cls.jpg
+sample_he.jpg
+testo.sh

--- a/main.py
+++ b/main.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         "--overlap",
         type=float,
         default=0.96875,
-        help="overlap between tiles, for conic, 0.96875 is best, for pannuke use 0.9375 for better results",
+        help="overlap between tiles, at 0.5mpp, 0.96875 is best, for 0.25mpp use 0.9375 for better results",
     )
     parser.add_argument(
         "--inf_workers",

--- a/src/post_process.py
+++ b/src/post_process.py
@@ -79,7 +79,6 @@ def post_process_main(
         )
     executor.shutdown(wait=False)
 
-
     if params["output_dir"] is not None:
         print("saving final output")
         zarr.save(os.path.join(params["output_dir"], "pinst_pp.zip"), pinst_out)
@@ -92,6 +91,6 @@ def post_process_main(
             create_tsvs(pcls_out, params)
             # TODO this is way to slow for large images
             if params["save_polygon"]:
-                create_polygon_output(pinst_out, pcls_out, params["output_dir"], params)
-   
+                create_polygon_output(pinst_out, pcls_out, params)
+
     return pinst_out

--- a/src/viz_utils.py
+++ b/src/viz_utils.py
@@ -1,11 +1,9 @@
 import os
 import numpy as np
-from skimage.measure import find_contours, regionprops
 import geojson
 import openslide
-from multiprocessing import Pool
-from functools import partial
-from tqdm.auto import tqdm
+import cv2
+from skimage.measure import regionprops
 from src.post_process_utils import get_openslide_info
 from src.constants import (
     CLASS_LABELS_LIZARD,
@@ -26,7 +24,7 @@ def create_geojson(polygons, classids, lookup, result_dir):
         poly = poly.tolist()
         # poly.append(poly[0])
         feature = geojson.Feature(
-            geometry=geojson.LineString(poly),
+            geometry=geojson.LineString(poly, precision=2),
             properties={
                 "Name": f"Nuc {i}",
                 "Type": "Polygon",
@@ -38,9 +36,8 @@ def create_geojson(polygons, classids, lookup, result_dir):
         )
         features.append(feature)
     feature_collection = geojson.FeatureCollection(features)
-    geojson_str = geojson.dumps(feature_collection, indent=2)
-    with open(result_dir + "/poly.geojson", "w") as f:
-        f.write(geojson_str)
+    with open(result_dir + "/poly.geojson", "w") as outfile:
+        geojson.dump(feature_collection, outfile)
 
 
 def create_tsvs(pcls_out, params):
@@ -88,33 +85,42 @@ def create_tsvs(pcls_out, params):
 
 
 def cont(x):
-    lab, im, bb = x
-    return (
-        lab,
-        (
-            np.around(
-                (
-                    np.array(find_contours(np.pad(im, 1, mode="constant"), 0.5)[0])
-                    + bb[0:2]
-                )
-            )
-        ).tolist(),
-    )
+    _, im, bb = x
+    im = np.pad(im.astype(np.uint8), 1, mode="constant", constant_values=0)
+
+    # initial contour finding
+    cont = cv2.findContours(
+        im,
+        mode=cv2.RETR_EXTERNAL,
+        method=cv2.CHAIN_APPROX_TC89_KCOS,
+    )[0][0].reshape(-1, 2)[:, [1, 0]]
+    # since opencv does not do "pixel" contours, we artificially do this for single pixel detections (if they exist)
+    if cont.shape[0] <= 1:
+        im = cv2.resize(im, None, fx=2.0, fy=2.0)
+        cont = (
+            cv2.findContours(
+                im,
+                mode=cv2.RETR_EXTERNAL,
+                method=cv2.CHAIN_APPROX_TC89_KCOS,
+            )[0][0].reshape(-1, 2)[:, [1, 0]]
+            / 2.0
+        )
+    cont = (cont + bb[0:2] - 1).tolist()
+    # close polygon:
+    cont.append(cont[0])
+    return cont
 
 
 def create_polygon_output(pinst, pcls_out, result_dir, params):
     # polygon output is slow and unwieldy, TODO
     pred_keys = CLASS_LABELS_PANNUKE if params["pannuke"] else CLASS_LABELS_LIZARD
-    props = [(p.label, p.image, p.bbox) for p in tqdm(regionprops(np.asarray(pinst)))]
+    # whole slide regionprops could be avoided to speed up this process...
+    print("getting all detections...")
+    props = [(p.label, p.image, p.bbox) for p in regionprops(np.asarray(pinst))]
     class_labels = [pcls_out[str(p[0])] for p in props]
-    with Pool(4) as pool:
-        res_poly = [
-            y[1]
-            for y in sorted(
-                pool.map(partial(cont), props),
-                key=lambda x: x[0],
-            )
-        ]
+    print("generating contours...")
+    res_poly = [cont(i) for i in props]
+    print("creating output...")
     create_geojson(
         res_poly,
         class_labels,


### PR DESCRIPTION
- post-processing now automatically estimated the scaling factor to be applied for the output depending on the resolution of the input image. This only works for WSI with proper metadata of course.
- geojson output now relies on opencv to create contours which even with rescaling is faster than scikit image, however outputs are slightly different since scikit image considers "half pixels" and opencv does not.