### PR TITLE
fixed small bug in npy post-processing

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -614,6 +614,9 @@ class NpyDataset(Dataset):
         self.store = np.load(path)
         if self.store.ndim == 3:
             self.store = self.store[np.newaxis, :]
+        if self.store.dtype != np.uint8:
+            print("converting input dtype to uint8")
+            self.store = self.store.astype(np.uint8)
         self.orig_shape = self.store.shape
         self.store = np.pad(
             self.store,

--- a/src/post_process_utils.py
+++ b/src/post_process_utils.py
@@ -50,7 +50,7 @@ def write(pinst_out, pcls_out, running_max, res, params):
     pinst_, pcls_, max_, t_, skip = res
     if not skip:
         if params["input_type"] != "wsi":
-            pinst_[pinst_ != 0] += running_max
+            pinst_.vindex[pinst_[:] != 0] += running_max
             pcls_ = {str(int(k) + running_max): v for k, v in pcls_.items()}
             props = [(p.label, p.centroid) for p in regionprops(pinst_)]
             pcls_new = {}


### PR DESCRIPTION
For npy input:

- previously did not use vindex and [:] which leads to wrong or no updates of pinst_
- Added small fix to when input image data is not uint8 

As discussed in #10 